### PR TITLE
Develop Issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Available Commands:
   version     Print the version number
 
 Flags:
+  -c, --cidr string     CIDR notation (e.g., 192.168.1.0/24)
   -e, --end string      ip range end
   -h, --help            help for reverse-scan
   -o, --output string   csv output file
@@ -40,16 +41,31 @@ Flags:
 Use "reverse-scan [command] --help" for more information about a command
 ```
 
-Run :
+Run with IP range:
 
 ```bash
 ./reverse-scan --start 37.160.0.0 --end 37.175.255.255 --output /tmp/out.csv -w 1024
 2017/06/30 15:01:29 Resolving from 37.160.0.0 to 37.175.255.255
-2017/06/30 15:01:29 Caluculated CIDR is 37.160.0.0/12
+2017/06/30 15:01:29 Calculated CIDR is 37.160.0.0/12
 2017/06/30 15:01:29 Number of IPs to scan: 1048576
 2017/06/30 15:01:29 Starting 1024 Workers
    9s [======================================================>-------------]  81%
 ```
 
-You specify the number of workers with the option `-w`, by default the utility start with 8 workers.
+Or run with CIDR notation:
+
+```bash
+./reverse-scan --cidr 127.0.0.1/24 --output /tmp/out.csv -w 1024
+2017/06/30 15:01:29 Resolving from 127.0.0.0 to 127.0.0.255
+2017/06/30 15:01:29 Calculated CIDR is 127.0.0.0/24
+2017/06/30 15:01:29 Number of IPs to scan: 256
+2017/06/30 15:01:29 Starting 1024 Workers
+   1s [===========================================================>------]  91%
+```
+
+You can specify either:
+- IP range using `--start` and `--end` flags, or
+- CIDR notation using `--cidr` flag
+
+You specify the number of workers with the option `-w`, by default the utility starts with 8 workers.
 You must also specify an output CSV file.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func NewRootCmd(v string) *cobra.Command {
 
 	rootCmd.PersistentFlags().StringP("start", "s", "", "ip range start")
 	rootCmd.PersistentFlags().StringP("end", "e", "", "ip range end")
+	rootCmd.PersistentFlags().StringP("cidr", "c", "", "CIDR notation (e.g., 192.168.1.0/24)")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "csv output file")
 	rootCmd.PersistentFlags().IntP("workers", "w", 8, "number of workers")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,11 @@ func LoadConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, err
 	}
 
+	cidr, err := cmd.Flags().GetString("cidr")
+	if err != nil {
+		return nil, err
+	}
+
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return nil, err
@@ -42,7 +47,7 @@ func LoadConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, err
 	}
 
-	config, err := validateConfig(start, end, output, workers)
+	config, err := validateConfig(start, end, cidr, output, workers)
 	if err != nil {
 		return nil, err
 	}
@@ -50,45 +55,84 @@ func LoadConfig(cmd *cobra.Command) (*Config, error) {
 	return config, nil
 }
 
-func validateConfig(start, end, output string, workers int) (*Config, error) {
-	if start == "" {
-		return nil, fmt.Errorf("must specify start range")
+func validateConfig(start, end, cidr, output string, workers int) (*Config, error) {
+	// Check that either CIDR or (start and end) are provided, but not both
+	hasCIDR := cidr != ""
+	hasStartEnd := start != "" || end != ""
+
+	if !hasCIDR && !hasStartEnd {
+		return nil, fmt.Errorf("must specify either --cidr or --start/--end range")
 	}
 
-	if end == "" {
-		return nil, fmt.Errorf("must specify end range")
+	if hasCIDR && hasStartEnd {
+		return nil, fmt.Errorf("cannot specify both --cidr and --start/--end range")
 	}
 
 	if output == "" {
 		return nil, fmt.Errorf("must specify output file")
 	}
 
-	startIP, err := utils.IsValidIP(start)
-	if err != nil {
-		return nil, err
-	}
-
-	endIP, err := utils.IsValidIP(end)
-	if err != nil {
-		return nil, err
-	}
-
-	if startIP[0] != endIP[0] {
-		return nil, fmt.Errorf("invalid range: start and end IP must be in the same network")
-	}
-
-	if endIP[2] < startIP[2] {
-		return nil, fmt.Errorf("invalid range: end IP must be greater than start IP")
-	}
-
 	if !utils.IsValidPath(output) {
 		return nil, fmt.Errorf("invalid output file: %q", output)
+	}
+
+	var startIP, endIP net.IP
+	var cidrStr string
+
+	if hasCIDR {
+		// Parse CIDR notation
+		ip, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR notation %q: %w", cidr, err)
+		}
+
+		// Get the first IP in the range
+		startIP = ip.Mask(ipnet.Mask)
+
+		// Get the last IP in the range
+		endIP = make(net.IP, len(startIP))
+		copy(endIP, startIP)
+		for i := range endIP {
+			endIP[i] |= ^ipnet.Mask[i]
+		}
+
+		cidrStr = cidr
+	} else {
+		// Validate start and end IPs
+		if start == "" {
+			return nil, fmt.Errorf("must specify start range")
+		}
+
+		if end == "" {
+			return nil, fmt.Errorf("must specify end range")
+		}
+
+		var err error
+		startIP, err = utils.IsValidIP(start)
+		if err != nil {
+			return nil, err
+		}
+
+		endIP, err = utils.IsValidIP(end)
+		if err != nil {
+			return nil, err
+		}
+
+		if startIP[0] != endIP[0] {
+			return nil, fmt.Errorf("invalid range: start and end IP must be in the same network")
+		}
+
+		if endIP[2] < startIP[2] {
+			return nil, fmt.Errorf("invalid range: end IP must be greater than start IP")
+		}
+
+		cidrStr = utils.GetCIDR(startIP, endIP)
 	}
 
 	config := Config{
 		StartIP: startIP,
 		EndIP:   endIP,
-		CIDR:    utils.GetCIDR(startIP, endIP),
+		CIDR:    cidrStr,
 		CSV:     output,
 		WORKERS: workers,
 	}


### PR DESCRIPTION
This commit adds support for specifying IP ranges using CIDR notation in addition to the existing start/end IP range method.

Changes:
- Added --cidr flag to command-line interface
- Updated config validation to support both CIDR and start/end inputs
- Added mutual exclusivity validation (cannot use both methods)
- Enhanced test suite with CIDR-specific test cases
- Updated README with CIDR usage examples and documentation

Users can now run:
  ./reverse-scan --cidr 127.0.0.1/24 --output out.csv

Instead of:
  ./reverse-scan --start 127.0.0.0 --end 127.0.0.255 --output out.csv

The implementation maintains full backward compatibility with the existing start/end range flags.