### PR TITLE
Set up goreleaser and svu for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
-    name: Create Release
+    name: Release with GoReleaser
     runs-on: ubuntu-latest
 
     steps:
@@ -34,42 +36,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Run tests
-        run: go test -v ./...
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Build binaries
-        run: |
-          # Linux
-          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o reverse-scan-linux-amd64
-          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o reverse-scan-linux-arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          # macOS
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o reverse-scan-darwin-amd64
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o reverse-scan-darwin-arm64
-
-          # Windows
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o reverse-scan-windows-amd64.exe
-
-          # FreeBSD
-          GOOS=freebsd GOARCH=amd64 go build -ldflags="-s -w" -o reverse-scan-freebsd-amd64
-
-      - name: Create checksums
-        run: |
-          sha256sum reverse-scan-* > checksums.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            reverse-scan-linux-amd64
-            reverse-scan-linux-arm64
-            reverse-scan-darwin-amd64
-            reverse-scan-darwin-arm64
-            reverse-scan-windows-amd64.exe
-            reverse-scan-freebsd-amd64
-            checksums.txt
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,62 @@
+name: Tag Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type (major, minor, patch, or auto)'
+        required: true
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create Version Tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install svu
+        run: |
+          curl -sL https://github.com/caarlos0/svu/releases/download/v2.3.0/svu_2.3.0_linux_amd64.tar.gz | tar xz
+          sudo mv svu /usr/local/bin/
+
+      - name: Get next version
+        id: version
+        run: |
+          if [ "${{ github.event.inputs.version_type }}" = "auto" ]; then
+            # svu will determine version based on conventional commits
+            NEXT_VERSION=$(svu next --tag-mode=current-branch)
+          else
+            # Use specified version type
+            NEXT_VERSION=$(svu ${{ github.event.inputs.version_type }})
+          fi
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "Next version will be: $NEXT_VERSION"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{ steps.version.outputs.next_version }} -m "Release ${{ steps.version.outputs.next_version }}"
+          git push origin ${{ steps.version.outputs.next_version }}
+
+      - name: Summary
+        run: |
+          echo "## Version Tag Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Version: \`${{ steps.version.outputs.next_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The release workflow will now be triggered automatically." >> $GITHUB_STEP_SUMMARY

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,155 @@
+# GoReleaser configuration for reverse-scan
+version: 2
+
+before:
+  hooks:
+    # Run tests before building
+    - go test -v ./...
+    # Ensure dependencies are up to date
+    - go mod tidy
+
+builds:
+  - id: reverse-scan
+    main: ./main.go
+    binary: reverse-scan
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      # FreeBSD arm64 is not commonly used
+      - goos: freebsd
+        goarch: arm64
+
+archives:
+  - id: reverse-scan
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - 'merge conflict'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'Enhancements'
+      regexp: "^.*enhancement[(\\w)]*:+.*$"
+      order: 2
+    - title: 'Documentation'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 3
+    - title: 'Other Changes'
+      order: 999
+
+release:
+  github:
+    owner: amine7536
+    name: reverse-scan
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## reverse-scan {{ .Version }}
+
+    Welcome to this new release of reverse-scan!
+
+  footer: |
+    ## Installation
+
+    ### Binary Download
+    Download the appropriate binary for your platform from the assets below.
+
+    ### Docker
+    ```bash
+    docker pull ghcr.io/amine7536/reverse-scan:{{ .Version }}
+    ```
+
+    ### Go Install
+    ```bash
+    go install github.com/amine7536/reverse-scan@{{ .Version }}
+    ```
+
+# Docker configuration
+dockers:
+  - image_templates:
+      - "ghcr.io/amine7536/reverse-scan:{{ .Version }}-amd64"
+      - "ghcr.io/amine7536/reverse-scan:latest-amd64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/amine7536/reverse-scan"
+
+  - image_templates:
+      - "ghcr.io/amine7536/reverse-scan:{{ .Version }}-arm64"
+      - "ghcr.io/amine7536/reverse-scan:latest-arm64"
+    use: buildx
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://github.com/amine7536/reverse-scan"
+
+docker_manifests:
+  - name_template: "ghcr.io/amine7536/reverse-scan:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/amine7536/reverse-scan:{{ .Version }}-amd64"
+      - "ghcr.io/amine7536/reverse-scan:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/amine7536/reverse-scan:latest"
+    image_templates:
+      - "ghcr.io/amine7536/reverse-scan:latest-amd64"
+      - "ghcr.io/amine7536/reverse-scan:latest-arm64"
+
+# Announce on GitHub Discussions (optional, can be enabled later)
+# announce:
+#   github:
+#     enabled: true
+#     message_template: 'reverse-scan {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+COPY reverse-scan /usr/local/bin/reverse-scan
+
+ENTRYPOINT ["/usr/local/bin/reverse-scan"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,33 @@ This utility uses the "Dispatcher/Workers" pattern discribed here :
 - https://nesv.github.io/golang/2014/02/25/worker-queues-in-go.html
 - http://marcio.io/2015/07/handling-1-million-requests-per-minute-with-golang/
 
-# Getting Started
+# Installation
 
-Download the binary :
+## Download Binary
+
+Download the latest binary from the [releases page](https://github.com/amine7536/reverse-scan/releases):
 
 ```bash
-wget https://github.com/amine7536/reverse-scan/releases/download/v0.2.1/reverse-scan
+# Example for Linux amd64
+wget https://github.com/amine7536/reverse-scan/releases/latest/download/reverse-scan_Linux_x86_64.tar.gz
+tar xzf reverse-scan_Linux_x86_64.tar.gz
 chmod +x reverse-scan
 ```
+
+## Docker
+
+```bash
+docker pull ghcr.io/amine7536/reverse-scan:latest
+docker run --rm ghcr.io/amine7536/reverse-scan:latest --help
+```
+
+## Go Install
+
+```bash
+go install github.com/amine7536/reverse-scan@latest
+```
+
+# Getting Started
 
 Usage :
 
@@ -69,3 +88,7 @@ You can specify either:
 
 You specify the number of workers with the option `-w`, by default the utility starts with 8 workers.
 You must also specify an output CSV file.
+
+# Development
+
+For information about the release process and how to create new releases, see [RELEASE.md](RELEASE.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,116 @@
+# Release Process
+
+This project uses [goreleaser](https://goreleaser.com/) and [svu](https://github.com/caarlos0/svu) for automated releases.
+
+## Overview
+
+- **goreleaser**: Handles building binaries for multiple platforms, creating archives, checksums, Docker images, and GitHub releases
+- **svu**: Semantic version utility that determines the next version based on git tags and conventional commits
+
+## Release Workflow
+
+### Option 1: Manual Tag Creation
+
+1. Create and push a tag manually:
+   ```bash
+   git tag -a v1.0.0 -m "Release v1.0.0"
+   git push origin v1.0.0
+   ```
+
+2. The release workflow will automatically trigger and:
+   - Build binaries for Linux, macOS, Windows, and FreeBSD (amd64 and arm64)
+   - Create archives and checksums
+   - Build multi-arch Docker images
+   - Create a GitHub release with auto-generated release notes
+
+### Option 2: Automated Versioning with svu
+
+1. Go to Actions → Tag Version workflow
+2. Click "Run workflow"
+3. Select version type:
+   - **auto**: Determines version automatically based on conventional commits
+   - **major**: Bumps major version (e.g., 1.0.0 → 2.0.0)
+   - **minor**: Bumps minor version (e.g., 1.0.0 → 1.1.0)
+   - **patch**: Bumps patch version (e.g., 1.0.0 → 1.0.1)
+
+4. The workflow will:
+   - Calculate the next version using svu
+   - Create and push the tag
+   - Automatically trigger the release workflow
+
+## Conventional Commits
+
+When using `auto` versioning, svu determines the version bump based on commit messages:
+
+- `feat:` or `feat(scope):` → Minor version bump
+- `fix:` or `fix(scope):` → Patch version bump
+- `BREAKING CHANGE:` or `!` → Major version bump
+
+Examples:
+```
+feat: add support for IPv6 scanning
+fix: resolve timeout issue in port scanner
+feat!: redesign configuration file format (breaking change)
+```
+
+## Release Artifacts
+
+Each release includes:
+
+- **Binaries**: For multiple platforms and architectures
+- **Archives**: `.tar.gz` (Unix) and `.zip` (Windows)
+- **Checksums**: SHA256 checksums in `checksums.txt`
+- **Docker Images**: Multi-arch images pushed to `ghcr.io/amine7536/reverse-scan`
+  - `ghcr.io/amine7536/reverse-scan:latest`
+  - `ghcr.io/amine7536/reverse-scan:v1.0.0`
+
+## Local Testing
+
+Test the goreleaser configuration locally:
+
+```bash
+# Install goreleaser
+go install github.com/goreleaser/goreleaser/v2@latest
+
+# Check configuration
+goreleaser check
+
+# Build snapshot (without publishing)
+goreleaser release --snapshot --clean --skip=publish
+
+# Test Docker build
+goreleaser release --snapshot --clean --skip=publish,sign
+```
+
+## Version Information
+
+The version is injected at build time using ldflags. When building manually:
+
+```bash
+go build -ldflags="-X main.Version=v1.0.0"
+```
+
+When using goreleaser, the version is automatically injected from the git tag.
+
+## Docker Images
+
+Docker images are built for both amd64 and arm64 architectures and published to GitHub Container Registry:
+
+```bash
+# Pull latest
+docker pull ghcr.io/amine7536/reverse-scan:latest
+
+# Pull specific version
+docker pull ghcr.io/amine7536/reverse-scan:v1.0.0
+```
+
+## Changelog
+
+Changelogs are automatically generated from commit messages and organized by type:
+- New Features
+- Bug Fixes
+- Enhancements
+- Documentation
+- Other Changes
+
+Commits starting with `docs:`, `test:`, `chore:`, or merge commits are excluded from the changelog.

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"github.com/amine7536/reverse-scan/cmd"
 )
 
-const (
-	// Version : app version
-	Version = "v0.2.3"
+var (
+	// Version : app version (injected by goreleaser at build time)
+	Version = "dev"
 )
 
 func main() {


### PR DESCRIPTION
This commit introduces a comprehensive release automation setup using goreleaser and svu:

Changes:
- Add .goreleaser.yml configuration with multi-platform builds (Linux, macOS, Windows, FreeBSD)
- Add Dockerfile.goreleaser for optimized container builds
- Update release.yml workflow to use goreleaser with Docker multi-arch support
- Add tag.yml workflow for automated version tagging with svu
- Add RELEASE.md documentation explaining the release process
- Update README.md with improved installation instructions (binary, Docker, go install)
- Update main.go to use build-time version injection instead of hardcoded version

Features:
- Automated semantic versioning with svu based on conventional commits
- Multi-architecture binary builds (amd64, arm64)
- Multi-architecture Docker images pushed to ghcr.io
- Automated changelog generation grouped by commit type
- Checksums and archive creation for all binaries
- Manual and automated release workflows

The release process now supports:
1. Manual tagging: Push a version tag to trigger release
2. Automated versioning: Use GitHub Actions workflow to calculate and tag next version